### PR TITLE
check gradle properties ossrhUsername and ossrhPassword only before publish task

### DIFF
--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -10,7 +10,6 @@ import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
-import org.gradle.api.publish.maven.tasks.PublishToMavenRepository;
 import org.gradle.api.tasks.javadoc.Javadoc;
 import org.gradle.external.javadoc.StandardJavadocDocletOptions;
 import org.gradle.plugins.signing.SigningExtension;

--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -120,6 +120,9 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
           // url
           mavenPom.getUrl().set(this.extension.url);
 
+          // description
+          mavenPom.getDescription().set(project.getDescription());
+
           // scm
           String repoName = this.extension.repoName.get();
           String scmConnection = String.format("scm:git:git://github.com/hypertrace/%s.git", repoName);

--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -79,17 +79,17 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
       url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/";
     }
 
-    getPublishingExtension().repositories(artifactRepositories ->
-      artifactRepositories.maven(mavenArtifactRepository -> {
-        mavenArtifactRepository.setUrl(url);
-        if (user.isPresent() && password.isPresent()) {
+    if (user.isPresent() && password.isPresent()) {
+      getPublishingExtension().repositories(artifactRepositories ->
+        artifactRepositories.maven(mavenArtifactRepository -> {
+          mavenArtifactRepository.setUrl(url);
           mavenArtifactRepository.credentials(passwordCredentials -> {
             passwordCredentials.setUsername(user.get());
             passwordCredentials.setPassword(password.get());
           });
-        }
-      })
-    );
+        })
+      );
+    }
   }
 
   private void addPublications() {
@@ -200,7 +200,7 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
   }
 
   private void validateGradlePropertiesBeforePublishTask() {
-    project.getTasks().withType(PublishToMavenRepository.class).stream().forEach(task -> {
+    project.getTasks().named("publish").configure(task -> {
       task.doFirst(unused -> {
         validateGradleProperty(PROPERTY_OSSRH_USERNAME);
         validateGradleProperty(PROPERTY_OSSRH_PASSWORD);


### PR DESCRIPTION
Gradle properties `ossrhUsername` and `ossrhPassword` are required for publishing artifacts to maven central. They need not to be set for tasks other than `publish`.