### PR TITLE
add gradle-nexus-staging-plugin for closing and releasing staged repositories

### DIFF
--- a/hypertrace-gradle-publish-maven-central-plugin/README.md
+++ b/hypertrace-gradle-publish-maven-central-plugin/README.md
@@ -24,10 +24,6 @@ hypertracePublishMavenCentral {
   license // REQUIRED to be a value defined in org.hypertrace.gradle.publishing.License
   repoName // REQUIRED. Name of the repository.
   url // Optional. The URL for the publication represented by the POM.
-  packageGroup // Optional. The package group as registered in Nexus staging profile.
-  stagingProfileId // Optional. The staging profile used to release given project.
-  numberOfRetries // Optional. The number of retries when waiting for a repository state transition to finish.
-  delayBetweenRetriesInMillis // Optional. The delay between retries.
 }
 ```
 

--- a/hypertrace-gradle-publish-maven-central-plugin/README.md
+++ b/hypertrace-gradle-publish-maven-central-plugin/README.md
@@ -15,6 +15,8 @@ For signing artifacts, following properties must be provided as gradle propertie
 - signingKey
 - signingPassword
 
+The plugin also uses [gradle-nexus-staging-plugin](https://github.com/Codearte/gradle-nexus-staging-plugin) plugin for closing and releasing staged repositories.
+
 Each property described below can be configured in the DSL. The default values are shown for each property,
 all of which, with the exception of license, can be omitted if left unchanged.
 ```kotlin
@@ -22,6 +24,10 @@ hypertracePublishMavenCentral {
   license // REQUIRED to be a value defined in org.hypertrace.gradle.publishing.License
   repoName // REQUIRED. Name of the repository.
   url // Optional. The URL for the publication represented by the POM.
+  packageGroup // Optional. The package group as registered in Nexus staging profile.
+  stagingProfileId // Optional. The staging profile used to release given project.
+  numberOfRetries // Optional. The number of retries when waiting for a repository state transition to finish.
+  delayBetweenRetriesInMillis // Optional. The delay between retries.
 }
 ```
 
@@ -50,4 +56,9 @@ subprojects {
 plugins {
   id("org.hypertrace.publish-maven-central-plugin") // No version required, set by parent
 }
+```
+
+#### Releasing repositories
+```bash
+./gradlew closeAndReleaseRepository
 ```

--- a/hypertrace-gradle-publish-maven-central-plugin/build.gradle.kts
+++ b/hypertrace-gradle-publish-maven-central-plugin/build.gradle.kts
@@ -23,6 +23,7 @@ gradlePlugin {
 
 dependencies {
   api(project(":hypertrace-gradle-publish-plugin"))
+  implementation("io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0")
   testImplementation("org.junit.jupiter:junit-jupiter-api:5.7.1")
   testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.7.1")
   testImplementation(gradleTestKit())

--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/HypertracePublishMavenCentralExtension.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/HypertracePublishMavenCentralExtension.java
@@ -25,9 +25,6 @@ public abstract class HypertracePublishMavenCentralExtension implements Extensio
   public final Property<String> developerOrganizationUrl;
   public final Property<License> license;
   public final Property<String> packageGroup;
-  public final Property<String> stagingProfileId;
-  public final Property<Integer> numberOfRetries;
-  public final Property<Integer> delayBetweenRetriesInMillis;
 
   @Inject
   public HypertracePublishMavenCentralExtension(ObjectFactory objectFactory) {
@@ -40,8 +37,5 @@ public abstract class HypertracePublishMavenCentralExtension implements Extensio
     this.developerOrganizationUrl = objectFactory.property(String.class).convention(DEFAULT_DEVELOPER_ORG_URL);
     this.license = objectFactory.property(License.class);
     this.packageGroup = objectFactory.property(String.class).convention(DEFAULT_PACKAGE_GROUP);
-    this.stagingProfileId = objectFactory.property(String.class);
-    this.numberOfRetries = objectFactory.property(Integer.class);
-    this.delayBetweenRetriesInMillis = objectFactory.property(Integer.class);
   }
 }

--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/HypertracePublishMavenCentralExtension.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/HypertracePublishMavenCentralExtension.java
@@ -14,6 +14,7 @@ public abstract class HypertracePublishMavenCentralExtension implements Extensio
   private static final String DEFAULT_DEVELOPER_EMAIL = "community@hypertrace.org";
   private static final String DEFAULT_DEVELOPER_ORG = "Hypertrace";
   private static final String DEFAULT_DEVELOPER_ORG_URL = "https://www.hypertrace.org";
+  private static final String DEFAULT_PACKAGE_GROUP = "org.hypertrace";
 
   public final Property<String> url;
   public final Property<String> repoName;
@@ -23,6 +24,10 @@ public abstract class HypertracePublishMavenCentralExtension implements Extensio
   public final Property<String> developerOrganization;
   public final Property<String> developerOrganizationUrl;
   public final Property<License> license;
+  public final Property<String> packageGroup;
+  public final Property<String> stagingProfileId;
+  public final Property<Integer> numberOfRetries;
+  public final Property<Integer> delayBetweenRetriesInMillis;
 
   @Inject
   public HypertracePublishMavenCentralExtension(ObjectFactory objectFactory) {
@@ -34,5 +39,9 @@ public abstract class HypertracePublishMavenCentralExtension implements Extensio
     this.developerOrganization = objectFactory.property(String.class).convention(DEFAULT_DEVELOPER_ORG);
     this.developerOrganizationUrl = objectFactory.property(String.class).convention(DEFAULT_DEVELOPER_ORG_URL);
     this.license = objectFactory.property(License.class);
+    this.packageGroup = objectFactory.property(String.class).convention(DEFAULT_PACKAGE_GROUP);
+    this.stagingProfileId = objectFactory.property(String.class);
+    this.numberOfRetries = objectFactory.property(Integer.class);
+    this.delayBetweenRetriesInMillis = objectFactory.property(Integer.class);
   }
 }

--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -1,12 +1,14 @@
 package org.hypertrace.gradle.publishing;
 
+import io.codearte.gradle.nexus.BaseStagingTask;
+import io.codearte.gradle.nexus.NexusStagingExtension;
+import io.codearte.gradle.nexus.NexusStagingPlugin;
 import org.gradle.api.GradleException;
 import org.gradle.api.JavaVersion;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.plugins.JavaPluginExtension;
-import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
@@ -42,11 +44,46 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
     this.applyWithSourcesJar();
     this.addPublishRepository();
     this.addPublications();
+    this.applyNexusStaging();
   }
 
   private void applySigning() {
     project.getPluginManager()
       .apply(SigningPlugin.class);
+  }
+
+  private void applyNexusStaging() {
+    project.getRootProject().getPluginManager()
+      .apply(NexusStagingPlugin.class);
+  }
+
+  private void configureNexusStagingPlugin() {
+    Optional<String> user = getProperty(PROPERTY_OSSRH_USERNAME);
+    Optional<String> password = getProperty(PROPERTY_OSSRH_PASSWORD);
+
+    getNexusStagingExtension().setServerUrl("https://s01.oss.sonatype.org/service/local/");
+    if (user.isPresent() && password.isPresent()) {
+      getNexusStagingExtension().setUsername(user.get());
+      getNexusStagingExtension().setPassword(password.get());
+    }
+
+    // packageGroup
+    getNexusStagingExtension().setPackageGroup(this.extension.packageGroup.get());
+
+    // stagingProfileId
+    if (this.extension.stagingProfileId.isPresent()) {
+      getNexusStagingExtension().setStagingProfileId(this.extension.stagingProfileId.get());
+    }
+
+    // numberOfRetries
+    if (this.extension.numberOfRetries.isPresent()) {
+      getNexusStagingExtension().setNumberOfRetries(this.extension.numberOfRetries.get());
+    }
+
+    // delayBetweenRetriesInMillis
+    if (this.extension.delayBetweenRetriesInMillis.isPresent()) {
+      getNexusStagingExtension().setDelayBetweenRetriesInMillis(this.extension.delayBetweenRetriesInMillis.get());
+    }
   }
 
   private void applyMavenPublish() {
@@ -99,6 +136,9 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
       validateGradlePropertiesBeforePublishTask();
       // sign after publication is added
       addSigning();
+      // configure staging plugin
+      configureNexusStagingPlugin();
+      validateGradlePropertiesBeforeStagingTasks();
     });
   }
 
@@ -192,6 +232,11 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
       .getByType(SigningExtension.class);
   }
 
+  private NexusStagingExtension getNexusStagingExtension() {
+    return project.getRootProject().getExtensions()
+      .getByType(NexusStagingExtension.class);
+  }
+
   private Optional<String> getProperty(String propertyName) {
     return Optional.ofNullable(project.findProperty(propertyName)).map(String::valueOf);
   }
@@ -209,6 +254,15 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
 
   private void validateGradlePropertiesBeforePublishTask() {
     project.getTasks().named("publish").configure(task -> {
+      task.doFirst(unused -> {
+        validateGradleProperty(PROPERTY_OSSRH_USERNAME);
+        validateGradleProperty(PROPERTY_OSSRH_PASSWORD);
+      });
+    });
+  }
+
+  private void validateGradlePropertiesBeforeStagingTasks() {
+    project.getRootProject().getTasks().withType(BaseStagingTask.class).stream().forEach(task -> {
       task.doFirst(unused -> {
         validateGradleProperty(PROPERTY_OSSRH_USERNAME);
         validateGradleProperty(PROPERTY_OSSRH_PASSWORD);

--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -69,21 +69,6 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
 
     // packageGroup
     getNexusStagingExtension().setPackageGroup(this.extension.packageGroup.get());
-
-    // stagingProfileId
-    if (this.extension.stagingProfileId.isPresent()) {
-      getNexusStagingExtension().setStagingProfileId(this.extension.stagingProfileId.get());
-    }
-
-    // numberOfRetries
-    if (this.extension.numberOfRetries.isPresent()) {
-      getNexusStagingExtension().setNumberOfRetries(this.extension.numberOfRetries.get());
-    }
-
-    // delayBetweenRetriesInMillis
-    if (this.extension.delayBetweenRetriesInMillis.isPresent()) {
-      getNexusStagingExtension().setDelayBetweenRetriesInMillis(this.extension.delayBetweenRetriesInMillis.get());
-    }
   }
 
   private void applyMavenPublish() {


### PR DESCRIPTION
After publishing artifacts to staging repositories, we have to manually close and release the staged repository:
https://central.sonatype.org/pages/releasing-the-deployment.html#close-and-drop-or-release-your-staging-repository

The plugin is updated to apply `gradle-nexus-staging-plugin` to automate the above process.