### PR TITLE
update publish plugin to publish artifacts to artifactory

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,6 @@ jobs:
         with: 
           args: publish
         env:
-          ORG_GRADLE_PROJECT_publishUser: ${{ secrets.BINTRAY_USER }}
-          ORG_GRADLE_PROJECT_publishApiKey: ${{ secrets.BINTRAY_API_KEY }}
-
-
+          ORG_GRADLE_PROJECT_artifactory_contextUrl: ${{ secrets.ARTIFACTORY_CONTEXT_URL }}
+          ORG_GRADLE_PROJECT_artifactory_user: ${{ secrets.ARTIFACTORY_PUBLISH_USER }}
+          ORG_GRADLE_PROJECT_artifactory_password: ${{ secrets.ARTIFACTORY_PUBLISH_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.hypertrace.gradle.publishing.License
 
 plugins {
   id("org.hypertrace.ci-utils-plugin") version "0.2.0"
-  id("org.hypertrace.publish-plugin") version "0.3.3" apply false
+  id("org.hypertrace.publish-plugin") version "0.4.4-SNAPSHOT" apply false
   id("org.hypertrace.repository-plugin") version "0.2.3"
 }
 

--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -179,7 +179,7 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
           // licenses
           mavenPom.licenses(mavenPomLicenseSpec -> {
             mavenPomLicenseSpec.license(mavenPomLicense -> {
-              mavenPomLicense.getName().set(this.extension.license.get().bintrayString);
+              mavenPomLicense.getName().set(this.extension.license.get().toString());
             });
           });
 

--- a/hypertrace-gradle-publish-plugin/README.md
+++ b/hypertrace-gradle-publish-plugin/README.md
@@ -18,7 +18,7 @@ all of which, with the exception of license, can be omitted if left unchanged.
 ```kotlin
  hypertracePublish {
       license // REQUIRED to be a value defined in org.hypertrace.gradle.publishing.License
-      url  // Optional.
+      pomUrl  // Optional. defaults to https://www.hypertrace.org/
   }
 ```
 

--- a/hypertrace-gradle-publish-plugin/README.md
+++ b/hypertrace-gradle-publish-plugin/README.md
@@ -3,12 +3,13 @@
 [![CircleCI](https://circleci.com/gh/hypertrace/hypertrace-gradle-publish-plugin.svg?style=svg)](https://circleci.com/gh/hypertrace/hypertrace-gradle-publish-plugin)
 
 ### Purpose
-This plugin configures the target project to publish its java artifacts to the Hypertrace bintray
-repository. It uses the `maven-publish` and `gradle-bintray-plugin` plugins internally to do this.
-By default, it will publish to https://dl.bintray.com/hypertrace/maven. The following credentials
+This plugin configures the target project to publish its java artifacts to the Hypertrace artifactory
+repository. It uses the `maven-publish` plugin internally to do this.
+The following credentials
 must be provided as gradle properties in the default configuration:
-- publishUser
-- publishApiKey
+- artifactory_contextUrl
+- artifactory_user
+- artifactory_password
 
 Additionally, no default value is provide for the license. This must be set explicitly via dsl.
 
@@ -17,29 +18,12 @@ all of which, with the exception of license, can be omitted if left unchanged.
 ```kotlin
  hypertracePublish {
       license // REQUIRED to be a value defined in org.hypertrace.gradle.publishing.License
-      vcsUrl // Optional. Defaults to the env var CIRCLE_REPOSITORY_URL
-      user // Optional. Defaults to gradle property publishUser
-      apiKey // Optional. Defaults to gradle property publishApiKey
-      repo // Optional. Defaults to "maven"
-      organization  // Optional. Defaults to "hypertrace"
-      name // Optional. Publication name, defaults to project.getName()
-      apiUrl // Optional. Defaults to https://api.bintray.com
+      url  // Optional.
   }
 ```
 
 Currently supported publications:
 - `java-library`: For projects applying `java-library`, the `java` component (i.e. the jar) will be registered as a publication
-
-### Tasks
-One task is added to the applied project, and one to the root project (if not defined).
-
-`bintrayUpload` - uploads all publications to bintray based on the provided config.
-This generally should not be used directly, because it requires an additional step to make
-artifacts generally available - either manually in the bintray UI, or programmatically with the
-`bintrayPublish` task.
-
-`bintrayPublish` - This depends on all `bintrayUpload` tasks and makes them publicly available. This
-task is hooked into the build lifecycle and will be called via `publish`  
 
 ### Example
 ```kotlin

--- a/hypertrace-gradle-publish-plugin/README.md
+++ b/hypertrace-gradle-publish-plugin/README.md
@@ -1,6 +1,6 @@
 # Hypertrace Publish Plugin
 ###### org.hypertrace.publish-plugin
-[![CircleCI](https://circleci.com/gh/hypertrace/hypertrace-gradle-publish-plugin.svg?style=svg)](https://circleci.com/gh/hypertrace/hypertrace-gradle-publish-plugin)
+[![Github](https://github.com/hypertrace/hypertrace-gradle-publish-plugin/actions/workflows/publish.yml/badge.svg)](https://github.com/hypertrace/hypertrace-gradle-publish-plugin/actions/workflows/publish.yml)
 
 ### Purpose
 This plugin configures the target project to publish its java artifacts to the Hypertrace artifactory

--- a/hypertrace-gradle-publish-plugin/build.gradle.kts
+++ b/hypertrace-gradle-publish-plugin/build.gradle.kts
@@ -20,32 +20,3 @@ gradlePlugin {
     }
   }
 }
-
-dependencies {
-  // Do not upgrade without reviewing. See PublishPlugin.createModuleMetadataPublication
-  implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5")
-
-  constraints {
-    implementation("org.apache.httpcomponents:httpclient:4.5.13") {
-      because("Multiple vulnerabilities in versions included via bintray plugin")
-    }
-    implementation("xerces:xercesImpl:2.12.1") {
-      because("Multiple vulnerabilities in versions included via bintray plugin")
-    }
-    implementation("commons-codec:commons-codec:1.13") {
-      because("version 1.12 vulnerable: https://snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518")
-    }
-    implementation("org.codehaus.plexus:plexus-utils:3.0.24") {
-      because("Multiple vulnerabilities in versions included via bintray plugin")
-    }
-    implementation("org.apache.ant:ant:1.10.9") {
-      because("Version 1.8.0 vulnerable: https://snyk.io/vuln/SNYK-JAVA-ORGAPACHEANT-569130")
-    }
-    implementation("commons-collections:commons-collections:3.2.2") {
-      because("Multiple vulnerabilities in versions included via bintray plugin")
-    }
-    implementation("commons-beanutils:commons-beanutils:1.9.4") {
-      because("Multiple vulnerabilities in versions included via bintray plugin")
-    }
-  }
-}

--- a/hypertrace-gradle-publish-plugin/src/main/java/org/hypertrace/gradle/publishing/HypertracePublishExtension.java
+++ b/hypertrace-gradle-publish-plugin/src/main/java/org/hypertrace/gradle/publishing/HypertracePublishExtension.java
@@ -1,52 +1,16 @@
 package org.hypertrace.gradle.publishing;
 
-import java.util.Optional;
 import javax.inject.Inject;
-import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 
 public class HypertracePublishExtension {
-
-  static final String BINTRAY_REPO_NAME = "maven";
-  static final String BINTRAY_ORG_NAME = "hypertrace";
-  static final String CIRCLECI_REPO_URL_ENV_VAR = "CIRCLE_REPOSITORY_URL";
-  static final String PUBLISH_USER_PROPERTY = "publishUser";
-  static final String PUBLISH_API_KEY_PROPERTY = "publishApiKey";
-  static final String DEFAULT_BINTRAY_API_URL = "https://api.bintray.com";
-  static final String UNSET = "unset";
-
   public final Property<License> license;
-  public final Property<String> vcsUrl;
-  public final Property<String> user;
-  public final Property<String> apiKey;
-  public final Property<String> repo;
-  public final Property<String> organization;
-  public final Property<String> name;
-  public final Property<String> apiUrl;
+  public final Property<String> url;
 
   @Inject
-  public HypertracePublishExtension(Project project, ObjectFactory objectFactory) {
+  public HypertracePublishExtension(ObjectFactory objectFactory) {
     this.license = objectFactory.property(License.class);
-    this.vcsUrl =
-        objectFactory
-            .property(String.class)
-            .convention(this.getEnvironmentVariable(CIRCLECI_REPO_URL_ENV_VAR).orElse(UNSET));
-    this.user = objectFactory.property(String.class);
-    this.getProperty(project, PUBLISH_USER_PROPERTY).ifPresent(this.user::convention);
-    this.apiKey = objectFactory.property(String.class);
-    this.getProperty(project, PUBLISH_API_KEY_PROPERTY).ifPresent(this.apiKey::convention);
-    this.repo = objectFactory.property(String.class).convention(BINTRAY_REPO_NAME);
-    this.organization = objectFactory.property(String.class).convention(BINTRAY_ORG_NAME);
-    this.name = objectFactory.property(String.class).convention(project.getName());
-    this.apiUrl = objectFactory.property(String.class).convention(DEFAULT_BINTRAY_API_URL);
-  }
-
-  private Optional<String> getProperty(Project project, String propertyName) {
-    return Optional.ofNullable(project.findProperty(propertyName)).map(String::valueOf);
-  }
-
-  private Optional<String> getEnvironmentVariable(String variableName) {
-    return Optional.ofNullable(System.getenv(variableName));
+    this.url = objectFactory.property(String.class);
   }
 }

--- a/hypertrace-gradle-publish-plugin/src/main/java/org/hypertrace/gradle/publishing/HypertracePublishExtension.java
+++ b/hypertrace-gradle-publish-plugin/src/main/java/org/hypertrace/gradle/publishing/HypertracePublishExtension.java
@@ -6,11 +6,11 @@ import org.gradle.api.provider.Property;
 
 public class HypertracePublishExtension {
   public final Property<License> license;
-  public final Property<String> url;
+  public final Property<String> pomUrl;
 
   @Inject
   public HypertracePublishExtension(ObjectFactory objectFactory) {
     this.license = objectFactory.property(License.class);
-    this.url = objectFactory.property(String.class);
+    this.pomUrl = objectFactory.property(String.class).convention("https://www.hypertrace.org/");
   }
 }

--- a/hypertrace-gradle-publish-plugin/src/main/java/org/hypertrace/gradle/publishing/License.java
+++ b/hypertrace-gradle-publish-plugin/src/main/java/org/hypertrace/gradle/publishing/License.java
@@ -2,11 +2,17 @@ package org.hypertrace.gradle.publishing;
 
 public enum License {
   TRACEABLE_COMMUNITY("Traceable"),
-  APACHE_2_0("Apache-2.0");
+  APACHE_2_0("Apache-2.0"),
+  PROPRIETARY("Proprietary");
 
-  public final String bintrayString;
+  private final String license;
 
-  License(String bintrayString) {
-    this.bintrayString = bintrayString;
+  License(String license) {
+    this.license = license;
+  }
+
+  @Override
+  public String toString() {
+    return license;
   }
 }

--- a/hypertrace-gradle-publish-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishPlugin.java
+++ b/hypertrace-gradle-publish-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishPlugin.java
@@ -1,217 +1,134 @@
 package org.hypertrace.gradle.publishing;
 
-import static org.apache.commons.lang.StringUtils.capitalize;
-import static org.gradle.api.publish.plugins.PublishingPlugin.PUBLISH_LIFECYCLE_TASK_NAME;
-import static org.hypertrace.gradle.publishing.HypertracePublishExtension.PUBLISH_API_KEY_PROPERTY;
-import static org.hypertrace.gradle.publishing.HypertracePublishExtension.PUBLISH_USER_PROPERTY;
-import static org.hypertrace.gradle.publishing.License.TRACEABLE_COMMUNITY;
-
-import com.jfrog.bintray.gradle.tasks.BintrayPublishTask;
-import com.jfrog.bintray.gradle.tasks.BintrayUploadTask;
-import java.util.Collection;
-import java.util.Collections;
-import javax.annotation.Nonnull;
 import org.gradle.api.GradleException;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
-import org.gradle.api.publish.Publication;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
-import org.gradle.api.publish.maven.internal.publication.MavenPublicationInternal;
 import org.gradle.api.publish.maven.plugins.MavenPublishPlugin;
-import org.gradle.api.publish.plugins.PublishingPlugin;
-import org.gradle.api.tasks.TaskProvider;
+
+import javax.annotation.Nonnull;
+import java.util.Optional;
 
 public class PublishPlugin implements Plugin<Project> {
 
+  private static final String REPOSITORY_KEY = "gradle";
   private static final String EXTENSION_NAME = "hypertracePublish";
-  // can't be changed, hardcoded into publish task.
-  private static final String UPLOAD_TASK_NAME = "bintrayUpload";
-  private static final String PUBLISH_TASK_NAME = "bintrayPublish";
+  private static final String PROPERTTY_ARTIFACTORY_USER = "artifactory_user";
+  private static final String PROPERTTY_ARTIFACTORY_PASSWORD = "artifactory_password";
+  private static final String PROPERTTY_ARTIFACTORY_CONTEXTURL = "artifactory_contextUrl";
+
   private Project project;
   private HypertracePublishExtension extension;
 
   @Override
   public void apply(@Nonnull Project target) {
     project = target;
-    this.extension =
-        project.getExtensions().create(EXTENSION_NAME, HypertracePublishExtension.class, project);
+    extension = project.getExtensions().create(EXTENSION_NAME, HypertracePublishExtension.class);
     this.applyMavenPublish();
+    this.addPublishRepository();
     this.addKnownPublications();
-    this.addUploadTask(this.setupRootForPublishingIfNeeded());
   }
 
   private void applyMavenPublish() {
-    project.getPluginManager().apply(MavenPublishPlugin.class);
+    project.getPluginManager()
+      .apply(MavenPublishPlugin.class);
+  }
+
+  private void addPublishRepository() {
+    Optional<String> user = getProperty(PROPERTTY_ARTIFACTORY_USER);
+    Optional<String> password = getProperty(PROPERTTY_ARTIFACTORY_PASSWORD);
+    Optional<String> contextUrl = getProperty(PROPERTTY_ARTIFACTORY_CONTEXTURL);
+
+    if (contextUrl.isPresent()) {
+      String url = contextUrl.get() + "/" + REPOSITORY_KEY;
+      getPublishingExtension().repositories(artifactRepositories -> {
+        artifactRepositories.maven(mavenArtifactRepository -> {
+          mavenArtifactRepository.setUrl(url);
+          if (user.isPresent() && password.isPresent()) {
+            mavenArtifactRepository.credentials(passwordCredentials -> {
+              passwordCredentials.setUsername(user.get());
+              passwordCredentials.setPassword(password.get());
+            });
+          }
+        });
+      });
+    }
   }
 
   private void addKnownPublications() {
+    validateGradlePropertiesBeforePublishTask();
     getPublishingExtension().publications(this::addJavaLibraryPublicationWhenApplied);
-  }
-
-  private void addUploadTask(TaskProvider<?> publishTask) {
-    TaskProvider<BintrayUploadTask> uploadTask =
-        this.getOrCreateTask(this.project, UPLOAD_TASK_NAME, BintrayUploadTask.class);
-    uploadTask.configure(task -> task.setEnabled(true));
-    publishTask.configure(task -> task.dependsOn(uploadTask));
-    project.afterEvaluate(unused -> uploadTask.configure(this::configureUploadTask));
-
-    this.getPublishingExtension()
-        .getPublications()
-        .withType(MavenPublication.class)
-        .all(
-            publication -> {
-              Collection<Task> dependencies =
-                  this.getDependenciesForPublication(project, publication);
-              if (dependencies.stream().noneMatch(Task::getEnabled)) {
-                return; // Ignore any publication that isn't actually publishing
-              }
-              this.addModuleMetadataPublication(publication);
-              uploadTask.configure(
-                  task -> {
-                    task.dependsOn(dependencies);
-                    task.setPublications(this.getPublishingExtension().getPublications().toArray());
-                  });
-            });
-  }
-
-  private TaskProvider<?> setupRootForPublishingIfNeeded() {
-    Project root = this.project.getRootProject();
-    root.getPluginManager().apply(PublishingPlugin.class);
-    this.addRootUploadTaskIfNeeded();
-    return this.getOrCreateRootPublishTask();
+    getPublishingExtension().publications(this::addDistributionPublicationWhenApplied);
   }
 
   private void addJavaLibraryPublicationWhenApplied(PublicationContainer publications) {
-    project
-        .getPluginManager()
-        .withPlugin(
-            "java-library",
-            appliedPlugin -> {
-              if (this.isJavaGradlePluginPluginApplied()) {
-                return; // This already creates publications, we don't want to duplicate
-              }
+    project.getPluginManager()
+      .withPlugin("java-library", appliedPlugin -> {
+        if (this.isJavaGradlePluginPluginApplied()) {
+          return; // This already creates a publication, we don't want to duplicate
+        }
+        publications.create("javaLibrary", MavenPublication.class, publication -> {
+          publication.from(project.getComponents().getByName("java"));
+          updatePomMetadata(publication);
+        });
+      });
+  }
 
-              publications.create(
-                  "javaLibrary",
-                  MavenPublication.class,
-                  publication -> publication.from(project.getComponents().getByName("java")));
-            });
+  private void addDistributionPublicationWhenApplied(PublicationContainer publications) {
+    project.getPluginManager()
+      .withPlugin("distribution", appliedPlugin ->
+        publications.create("distributionZip", MavenPublication.class, publication ->
+          publication.artifact(project.getTasks()
+            .getByName("distZip"))));
+  }
+
+  private void updatePomMetadata(MavenPublication publication) {
+    publication.pom(mavenPom -> {
+      // Add url
+      mavenPom.getUrl().set(extension.url);
+
+      // Add license
+      if (extension.license.isPresent()) {
+        mavenPom.licenses(mavenPomLicenseSpec -> {
+          mavenPomLicenseSpec.license(mavenPomLicense -> {
+            mavenPomLicense.getName().set(this.extension.license.get().bintrayString);
+          });
+        });
+      }
+    });
   }
 
   private PublishingExtension getPublishingExtension() {
-    return project.getExtensions().getByType(PublishingExtension.class);
+    return project.getExtensions()
+      .getByType(PublishingExtension.class);
+  }
+
+  private Optional<String> getProperty(String propertyName) {
+    return Optional.ofNullable(project.findProperty(propertyName)).map(String::valueOf);
   }
 
   private boolean isJavaGradlePluginPluginApplied() {
-    return project.getPluginManager().hasPlugin("java-gradle-plugin");
+    return project.getPluginManager()
+      .hasPlugin("java-gradle-plugin");
   }
 
-  private void configureUploadTask(BintrayUploadTask task) {
-    this.validateExtensionAtConfigurationTime();
-    task.doFirst(unused -> this.validateExtensionAtExecutionTime());
-    Project project = task.getProject();
-    task.project = project; // Why do they have their own var?
-    task.setUser(this.extension.user.getOrNull());
-    task.setApiKey(this.extension.apiKey.getOrNull());
-    task.setApiUrl(this.extension.apiUrl.get());
-    task.setPublish(true);
-    task.setOverride(false);
-    task.setRepoName(this.extension.repo.get());
-    task.setPackageName(this.extension.name.get());
-    task.setPackageVcsUrl(this.extension.vcsUrl.get());
-    task.setUserOrg(this.extension.organization.get());
-    if (this.extension.license.get() != TRACEABLE_COMMUNITY) {
-      // The bintray plugin doesn't support custom licenses. This is the default on all repos.
-      task.setPackageLicenses(this.extension.license.get().bintrayString);
+  private void validateGradlePropertiesBeforePublishTask() {
+    project.getTasks().named("publish").configure(task -> {
+      task.doFirst(unused -> {
+        validateGradleProperty(PROPERTTY_ARTIFACTORY_CONTEXTURL);
+        validateGradleProperty(PROPERTTY_ARTIFACTORY_USER);
+        validateGradleProperty(PROPERTTY_ARTIFACTORY_PASSWORD);
+      });
+    });
+  }
+
+  private void validateGradleProperty(String propertyName) {
+    if (!project.hasProperty(propertyName)) {
+      throw new GradleException("Missing expected gradle property: " + propertyName + ". It should be added " +
+        "in your ~/.gradle/gradle.properties file, or in a an environment variable of the form " +
+        "ORG_GRADLE_PROJECT_" + propertyName);
     }
-    task.setVersionName(String.valueOf(project.getVersion()));
-  }
-
-  private Collection<Task> getDependenciesForPublication(Project project, Publication publication) {
-    if (!(publication instanceof MavenPublication)) {
-      return Collections.emptySet();
-    }
-    return project.getTasksByName(this.getPublishLocalTaskNameForPublication(publication), false);
-  }
-
-  private String getPublishLocalTaskNameForPublication(Publication publication) {
-    return String.format("publish%sPublicationToMavenLocal", capitalize(publication.getName()));
-  }
-
-  private void validateExtensionAtConfigurationTime() {
-    if (!this.extension.license.isPresent()) {
-      throw new GradleException(
-          "A license type must be specified in the build DSL to use the Hypertrace publish plugin");
-    }
-  }
-
-  private void validateExtensionAtExecutionTime() {
-    if (!this.extension.user.isPresent()) {
-      throw new GradleException(
-          String.format(
-              "A bintray user must be provided to run %s. Please provide one through the DSL as %s.user or the gradle property %s",
-              UPLOAD_TASK_NAME, EXTENSION_NAME, PUBLISH_USER_PROPERTY));
-    }
-    if (!this.extension.apiKey.isPresent()) {
-      throw new GradleException(
-          String.format(
-              "A bintray API Key must be provided to run %s. Please provide one through the DSL as %s.apiKey or the gradle property %s",
-              UPLOAD_TASK_NAME, EXTENSION_NAME, PUBLISH_API_KEY_PROPERTY));
-    }
-  }
-
-  private TaskProvider<?> getOrCreateRootPublishTask() {
-    TaskProvider<?> taskProvider =
-        this.getOrCreateTask(project.getRootProject(), PUBLISH_TASK_NAME, BintrayPublishTask.class);
-    project
-        .getRootProject()
-        .getTasks()
-        .named(PUBLISH_LIFECYCLE_TASK_NAME)
-        .configure(task -> task.dependsOn(taskProvider));
-    return taskProvider;
-  }
-
-  private void addRootUploadTaskIfNeeded() {
-    this.getOrCreateTask(project.getRootProject(), UPLOAD_TASK_NAME, BintrayUploadTask.class)
-        .configure(
-            task -> {
-              task.setEnabled(false);
-              task.project = project.getRootProject();
-            });
-  }
-
-  private <T extends Task> TaskProvider<T> getOrCreateTask(
-      Project project, String name, Class<T> taskClass) {
-    try {
-      return project.getTasks().withType(taskClass).named(name);
-    } catch (Exception ignored) {
-      return project.getTasks().register(name, taskClass);
-    }
-  }
-
-  /*
-   Bug in bintray plugin prevents the gradle metadata from being published normally. This is a hack
-   to publish it explicitly. TODO: remove once bintray plugin handles this -
-   https://github.com/bintray/gradle-bintray-plugin/pull/306
-   Once the plugin handles this, this extra publication will duplicate the artifact and cause
-   publish failures.
-  */
-  private void addModuleMetadataPublication(MavenPublication publication) {
-    // This call will resolve a publication - we don't want to do that until other plugins have
-    // finished setting up, so wait til after evaluate
-    project.afterEvaluate(
-        unused -> {
-          if (publication instanceof MavenPublicationInternal) {
-            // Extract the module metadata artifact, and re-register it as a first class artifact
-            ((MavenPublicationInternal) publication)
-                .getPublishableArtifacts().stream()
-                    .filter(mavenArtifact -> mavenArtifact.getExtension().equals("module"))
-                    .findFirst()
-                    .ifPresent(publication::artifact);
-          }
-        });
   }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -3,7 +3,7 @@ pluginManagement {
     mavenLocal()
     gradlePluginPortal()
     maven {
-      url = uri("https://dl.bintray.com/hypertrace/maven")
+      url = uri("https://hypertrace.jfrog.io/artifactory/gradle")
     }
   }
 }


### PR DESCRIPTION
Bintray services will be deprecated on 1 May 2021: https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/
We are planning to use an artifactory instance for Hypertrace artifacts: https://hypertrace.jfrog.io/

The `publish-plugin` is being updated to publish artifacts to artifactory.
