### PR TITLE
🔧  allow configuration of scm organizationi in pom attributes

### DIFF
--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/HypertracePublishMavenCentralExtension.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/HypertracePublishMavenCentralExtension.java
@@ -1,6 +1,5 @@
 package org.hypertrace.gradle.publishing;
 
-import org.hypertrace.gradle.publishing.License;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.provider.Property;
@@ -15,6 +14,7 @@ public abstract class HypertracePublishMavenCentralExtension implements Extensio
   private static final String DEFAULT_DEVELOPER_ORG = "Hypertrace";
   private static final String DEFAULT_DEVELOPER_ORG_URL = "https://www.hypertrace.org";
   private static final String DEFAULT_PACKAGE_GROUP = "org.hypertrace";
+  private static final String DEFAULT_SCM_ORGANIZATION = "hypertrace";
 
   public final Property<String> url;
   public final Property<String> repoName;
@@ -25,6 +25,7 @@ public abstract class HypertracePublishMavenCentralExtension implements Extensio
   public final Property<String> developerOrganizationUrl;
   public final Property<License> license;
   public final Property<String> packageGroup;
+  public final Property<String> scmOrganization;
 
   @Inject
   public HypertracePublishMavenCentralExtension(ObjectFactory objectFactory) {
@@ -37,5 +38,6 @@ public abstract class HypertracePublishMavenCentralExtension implements Extensio
     this.developerOrganizationUrl = objectFactory.property(String.class).convention(DEFAULT_DEVELOPER_ORG_URL);
     this.license = objectFactory.property(License.class);
     this.packageGroup = objectFactory.property(String.class).convention(DEFAULT_PACKAGE_GROUP);
+    this.scmOrganization = objectFactory.property(String.class).convention(DEFAULT_SCM_ORGANIZATION);
   }
 }

--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -104,6 +104,7 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
     if (user.isPresent() && password.isPresent()) {
       getPublishingExtension().repositories(artifactRepositories ->
         artifactRepositories.maven(mavenArtifactRepository -> {
+          mavenArtifactRepository.setName("mavenCentral");
           mavenArtifactRepository.setUrl(url);
           mavenArtifactRepository.credentials(passwordCredentials -> {
             passwordCredentials.setUsername(user.get());

--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -156,9 +156,10 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
 
           // scm
           String repoName = this.extension.repoName.get();
-          String scmConnection = String.format("scm:git:git://github.com/hypertrace/%s.git", repoName);
-          String scmDeveloperConnection = String.format("scm:git:ssh://github.com:hypertrace/%s.git", repoName);
-          String scmUrl = String.format("https://github.com/hypertrace/%s/tree/main", repoName);
+          String scmOrganization = this.extension.scmOrganization.get();
+          String scmConnection = String.format("scm:git:git://github.com/%s/%s.git", scmOrganization, repoName);
+          String scmDeveloperConnection = String.format("scm:git:ssh://github.com:%s/%s.git", scmOrganization, repoName);
+          String scmUrl = String.format("https://github.com/%s/%s/tree/main", scmOrganization, repoName);
           mavenPom.scm(mavenPomScm -> {
             mavenPomScm.getConnection().set(scmConnection);
             mavenPomScm.getDeveloperConnection().set(scmDeveloperConnection);

--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -9,6 +9,7 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.UnknownDomainObjectException;
 import org.gradle.api.plugins.JavaPluginExtension;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.publish.PublicationContainer;
 import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
@@ -156,15 +157,21 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
           mavenPom.getDescription().set(project.getDescription());
 
           // scm
-          String repoName = this.extension.repoName.get();
-          String scmOrganization = this.extension.scmOrganization.get();
-          String scmConnection = String.format("scm:git:git://github.com/%s/%s.git", scmOrganization, repoName);
-          String scmDeveloperConnection = String.format("scm:git:ssh://github.com:%s/%s.git", scmOrganization, repoName);
-          String scmUrl = String.format("https://github.com/%s/%s/tree/main", scmOrganization, repoName);
+          Provider<String> qualifiedRepoProvider =
+              this.extension.scmOrganization.flatMap(
+                  repoName ->
+                      this.extension.repoName.map(
+                          orgName -> String.format("%s/%s", orgName, repoName)));
+          Provider<String> scmConnectionProvider =
+              qualifiedRepoProvider.map(qualifiedRepo -> String.format("scm:git:git://github.com/%s.git", qualifiedRepo));
+          Provider<String> scmDeveloperConnectionProvider =
+              qualifiedRepoProvider.map(qualifiedRepo -> String.format("scm:git:ssh://github.com:%s.git", qualifiedRepo));
+          Provider<String> scmUrlProvider =
+              qualifiedRepoProvider.map(qualifiedRepo ->  String.format("https://github.com/%s/tree/main", qualifiedRepo));
           mavenPom.scm(mavenPomScm -> {
-            mavenPomScm.getConnection().set(scmConnection);
-            mavenPomScm.getDeveloperConnection().set(scmDeveloperConnection);
-            mavenPomScm.getUrl().set(scmUrl);
+            mavenPomScm.getConnection().set(scmConnectionProvider);
+            mavenPomScm.getDeveloperConnection().set(scmDeveloperConnectionProvider);
+            mavenPomScm.getUrl().set(scmUrlProvider);
           });
 
           // developers


### PR DESCRIPTION
## Description
Allows the Maven SCM attributes to be configured to not use hypertrace as the github organization. I thought about reusing the developer ID property, but I don't think those two are necessarily the same thing so I think we're best off to keep those concepts separated.


In addition, I modified the Maven publication created by this plugin to have a non-default name. This helps developers using the plugin to discriminate between various publication repositories and have multiple configured. A common workflow to have would be to have a project leveraging this plugin publish to an internal artifact repository, like Artifactory, by default. If a project was using both the `hypertrace-gradle-publish-plugin` and the `hypertrace-gradle-publish-maven-central-plugin` to do this, one publication would override the other because they both have the same name (by default, `maven`).


### Testing
Tested the plugin on my local machine with a project not namespace in Hypertrace's github org.

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (based on existing tests, this didn't seem necessary)
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation

No docs change required

<!--
Include __important__ links regarding the implementatxion of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
