### PR TITLE
🐛  fix order of arguments in qualifiedRepoProvider

### DIFF
--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -159,9 +159,9 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
           // scm
           Provider<String> qualifiedRepoProvider =
               this.extension.scmOrganization.flatMap(
-                  repoName ->
+                  orgName ->
                       this.extension.repoName.map(
-                          orgName -> String.format("%s/%s", orgName, repoName)));
+                          repoName -> String.format("%s/%s", orgName, repoName)));
           Provider<String> scmConnectionProvider =
               qualifiedRepoProvider.map(qualifiedRepo -> String.format("scm:git:git://github.com/%s.git", qualifiedRepo));
           Provider<String> scmDeveloperConnectionProvider =


### PR DESCRIPTION
Minor bug fix, I didn't notice the order of the property names were swapped so it resulted in Maven pom attributes like 
```xml
 <scm>
    <connection>scm:git:git://github.com/javaagent/traceableai.git</connection>
    <developerConnection>scm:git:ssh://github.com:javaagent/traceableai.git</developerConnection>
    <url>https://github.com/javaagent/traceableai/tree/main</url>
  </scm>

```

## Description
fix name of arguments so that the qualified repo provider string is constructed correctly

<!--
- **on a feature**: describe the feature and how this change fits in it, e.g. this PR makes kafka message.max.bytes configurable to better support batching
- **on a refactor**: describe why this is better than previous situation e.g. this PR changes logic for retry on healthchecks to avoid false positives
- **on a bugfix**: link relevant information about the bug (github issue or slack thread) and how this change solves it e.g. this change fixes #99999 by adding a lock on read/write to avoid data races.
-->


### Testing
Please describe the tests that you ran to verify your changes. Please summarize what did you test and what needs to be tested e.g. deployed and tested helm chart locally. 

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

### Documentation
N/A

<!--
Include __important__ links regarding the implementation of this PR.
This usually includes and RFC or an aggregation of issues and/or individual conversations that helped put this solution together. This helps ensure there is a good aggregation of resources regarding the implementation.
-->
