### PR TITLE
NO-TICKET: publish via central publisher portal

### DIFF
--- a/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
+++ b/hypertrace-gradle-publish-maven-central-plugin/src/main/java/org/hypertrace/gradle/publishing/PublishMavenCentralPlugin.java
@@ -109,9 +109,9 @@ public class PublishMavenCentralPlugin implements Plugin<Project> {
     Optional<String> password = getProperty(PROPERTY_OSSRH_PASSWORD);
 
     if (project.getVersion().toString().endsWith("SNAPSHOT")) {
-      url = "https://s01.oss.sonatype.org/content/repositories/snapshots/";
+      url = "https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/";
     } else {
-      url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/";
+      url = "https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/";
     }
 
     if (user.isPresent() && password.isPresent()) {


### PR DESCRIPTION
The OSSRH service has reached end-of-life on [June 30th, 2025](https://central.sonatype.org/news/20250326_ossrh_sunset/).

Changing urls to publish by using the [Portal OSSRH Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/)